### PR TITLE
Configure build for brew-installed curl on macOS

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,14 @@ val http4sVersion = "0.23.14-101-02562a0-SNAPSHOT"
 val munitCEVersion = "2.0-4e051ab-SNAPSHOT"
 ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
+ThisBuild / nativeConfig ~= { c =>
+  val osName = Option(System.getProperty("os.name"))
+  val isMacOs = osName.exists(_.toLowerCase().contains("mac"))
+  if (isMacOs) { // brew-installed curl
+    c.withLinkingOptions(c.linkingOptions :+ "-L/usr/local/opt/curl/lib")
+  } else c
+}
+
 lazy val root = project.in(file(".")).enablePlugins(NoPublishPlugin).aggregate(curl, example)
 
 lazy val curl = project


### PR DESCRIPTION
Cherry-picking out of https://github.com/http4s/http4s-curl/pull/5#issuecomment-1225159297. We can't add macOS to CI yet because of https://github.com/http4s/http4s-curl/issues/6. But this fix is good so I would like to get it onto main.